### PR TITLE
[Bug] When renaming "Uncategorized", a limit of 0 is added

### DIFF
--- a/lib/screens/allocate_income_screen.dart
+++ b/lib/screens/allocate_income_screen.dart
@@ -96,9 +96,6 @@ class _AllocateIncomeScreenState extends State<AllocateIncomeScreen> {
     return (amount / totalIncome) * 100.0;
   }
 
-  bool _isUncategorizedName(String name) =>
-      name.trim().toLowerCase() == 'uncategorized';
-
   TextEditingController _ensureController(String id, String initialText) {
     return ctrls.putIfAbsent(
         id, () => TextEditingController(text: initialText));
@@ -187,8 +184,9 @@ class _AllocateIncomeScreenState extends State<AllocateIncomeScreen> {
     final store = context.watch<BudgetStore>();
     final b = store.currentBudget!;
     _totalIncome = b.totalIncome;
-    final allocCategories =
-        b.categories.where((c) => !_isUncategorizedName(c.name)).toList();
+    final allocCategories = b.categories
+        .where((c) => !store.isUncategorizedCategory(c, budget: b))
+        .toList();
 
     for (final c in allocCategories) {
       _ensureDraftForCategory(c.id, c.allocated);
@@ -212,7 +210,7 @@ class _AllocateIncomeScreenState extends State<AllocateIncomeScreen> {
       try {
         final saveAllocations = Map<String, double>.from(draftAmounts);
         for (final c in b.categories) {
-          if (_isUncategorizedName(c.name)) {
+          if (store.isUncategorizedCategory(c, budget: b)) {
             saveAllocations[c.id] = 0.0;
           }
         }
@@ -361,7 +359,8 @@ class _AllocateIncomeScreenState extends State<AllocateIncomeScreen> {
                             res.emoji,
                           );
 
-                          if (!_isUncategorizedName(newCat.name)) {
+                          if (!store.isUncategorizedCategory(newCat,
+                              budget: b)) {
                             draftAmounts[newCat.id] = 0.0;
 
                             final text = usePercent ? '0' : _fmtAmount(0.0);

--- a/lib/screens/category_detail_screen.dart
+++ b/lib/screens/category_detail_screen.dart
@@ -58,7 +58,7 @@ class _CategoryDetailScreenState extends State<CategoryDetailScreen> {
     final otherCategories = b.categories
         .where((c) => c.id != widget.categoryId)
         .toList(growable: false);
-    final isUncategorized = cat.name.trim().toLowerCase() == 'uncategorized';
+    final isUncategorized = store.isUncategorizedCategory(cat, budget: b);
     final expenseItems = _sortedExpenses(cat.expenses);
 
     final spent = cat.spent;
@@ -78,18 +78,18 @@ class _CategoryDetailScreenState extends State<CategoryDetailScreen> {
                 ? (
                     _CategoryBudgetTone.healthy,
                     'On track',
-                    'Less than 50% of this category has been spent.',
+                    'Less than 50% of this category has been spent',
                   )
                 : rawRatio <= 0.8
                     ? (
                         _CategoryBudgetTone.warning,
                         'Keep an eye on it',
-                        'Between 51% and 80% of this category is already used.',
+                        'Between 51% and 80% of this category is already used',
                       )
                     : (
                         _CategoryBudgetTone.danger,
                         'Close to the limit',
-                        'More than 80% of this category has been spent.',
+                        'More than 80% of this category has been spent',
                       );
 
     final statusColor = switch (tone) {

--- a/lib/screens/month_screen.dart
+++ b/lib/screens/month_screen.dart
@@ -85,23 +85,6 @@ class _MonthScreenState extends State<MonthScreen> {
     }
   }
 
-  String _resolveCategoryForExpense(BudgetStore store, String? categoryId) {
-    final b = store.currentBudget!;
-    if (categoryId != null && b.categories.any((c) => c.id == categoryId)) {
-      return categoryId;
-    }
-
-    Category? uncategorized;
-    for (final c in b.categories) {
-      if (c.name.trim().toLowerCase() == 'uncategorized') {
-        uncategorized = c;
-        break;
-      }
-    }
-
-    return (uncategorized ?? store.addCategory('Uncategorized', '🗂️')).id;
-  }
-
   Future<void> _showAddExpenseDialog() async {
     final store = context.read<BudgetStore>();
     final b = store.currentBudget;
@@ -113,7 +96,7 @@ class _MonthScreenState extends State<MonthScreen> {
     );
     if (!mounted || result == null) return;
 
-    final categoryId = _resolveCategoryForExpense(store, result.categoryId);
+    final categoryId = store.resolveExpenseCategoryId(result.categoryId);
     store.addExpense(
       categoryId,
       result.note,
@@ -311,6 +294,10 @@ class _MonthScreenState extends State<MonthScreen> {
         initialName: category.name,
         initialEmoji: category.emoji,
         initialAllocated: category.allocated,
+        allowEmojiEditing:
+            !context.read<BudgetStore>().isUncategorizedCategory(category),
+        showLimitField:
+            !context.read<BudgetStore>().isUncategorizedCategory(category),
       ),
     );
 
@@ -484,7 +471,7 @@ class _MonthScreenState extends State<MonthScreen> {
     final overallDebt = store.debtForBudget(b);
     final overCats = b.categories
         .where((c) =>
-            c.name.trim().toLowerCase() != 'uncategorized' &&
+            !store.isUncategorizedCategory(c, budget: b) &&
             c.spent > c.allocated)
         .toList();
     final statusColor = _statusColor(b.totalIncome, effectiveExpenses);
@@ -718,6 +705,7 @@ class _MonthScreenState extends State<MonthScreen> {
               ),
             ...b.categories.map((c) => CategoryCard(
                   category: c,
+                  isUncategorized: store.isUncategorizedCategory(c, budget: b),
                   currencySymbol: store.currency.symbol,
                   onTap: () {
                     Navigator.of(context).push(

--- a/lib/state/budget_store.dart
+++ b/lib/state/budget_store.dart
@@ -25,8 +25,14 @@ enum CarryForwardDebtResult {
 }
 
 class BudgetStore extends ChangeNotifier {
+  static const String uncategorizedName = 'Uncategorized';
+  static const String uncategorizedEmoji = '🗂️';
+  static const String _uncategorizedCategoryIdsPrefsKey =
+      'uncategorized_category_ids';
+
   final Map<String, MonthBudget> _budgets = {}; // key: YYYY-MM
   final Set<String> _dismissedTipIds = <String>{};
+  final Map<String, String> _uncategorizedCategoryIds = <String, String>{};
   String? selectedYMKey;
   Currency currency = const Currency('GBP', '£');
   ThemeMode themeMode = ThemeMode.system;
@@ -34,6 +40,7 @@ class BudgetStore extends ChangeNotifier {
 
   // File persistence
   File? _dbFile;
+  SharedPreferences? _prefs;
   Timer? _saveDebounce;
 
   UnmodifiableMapView<String, MonthBudget> get budgets =>
@@ -124,17 +131,123 @@ class BudgetStore extends ChangeNotifier {
     }
   }
 
-  Category _ensureUncategorized(MonthBudget b) {
-    for (final c in b.categories) {
-      if (c.name.trim().toLowerCase() == 'uncategorized') return c;
+  bool _isUncategorizedName(String name) =>
+      name.trim().toLowerCase() == uncategorizedName.toLowerCase();
+
+  String _monthKeyForBudget(MonthBudget budget) =>
+      _keyOf(budget.year, budget.month);
+
+  Category? _categoryById(MonthBudget budget, String categoryId) {
+    for (final category in budget.categories) {
+      if (category.id == categoryId) return category;
     }
+    return null;
+  }
+
+  Map<String, String> _decodeUncategorizedCategoryIds(String? raw) {
+    if (raw == null || raw.trim().isEmpty) return <String, String>{};
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map<String, dynamic>) return <String, String>{};
+      final ids = <String, String>{};
+      decoded.forEach((key, value) {
+        if (value is String && value.isNotEmpty) {
+          ids[key] = value;
+        }
+      });
+      return ids;
+    } catch (_) {
+      return <String, String>{};
+    }
+  }
+
+  Future<void> _saveUncategorizedCategoryIds() async {
+    final prefs = _prefs;
+    if (prefs == null) return;
+    if (_uncategorizedCategoryIds.isEmpty) {
+      await prefs.remove(_uncategorizedCategoryIdsPrefsKey);
+      return;
+    }
+    await prefs.setString(
+      _uncategorizedCategoryIdsPrefsKey,
+      jsonEncode(_uncategorizedCategoryIds),
+    );
+  }
+
+  void _rememberUncategorizedCategory(MonthBudget budget, String categoryId) {
+    final monthKey = _monthKeyForBudget(budget);
+    if (_uncategorizedCategoryIds[monthKey] == categoryId) return;
+    _uncategorizedCategoryIds[monthKey] = categoryId;
+    _saveUncategorizedCategoryIds();
+  }
+
+  void _forgetUncategorizedCategory(
+    MonthBudget budget, {
+    String? expectedCategoryId,
+  }) {
+    final monthKey = _monthKeyForBudget(budget);
+    final rememberedId = _uncategorizedCategoryIds[monthKey];
+    if (rememberedId == null) return;
+    if (expectedCategoryId != null && rememberedId != expectedCategoryId) {
+      return;
+    }
+    _uncategorizedCategoryIds.remove(monthKey);
+    _saveUncategorizedCategoryIds();
+  }
+
+  Category? _findUncategorized(MonthBudget budget) {
+    final monthKey = _monthKeyForBudget(budget);
+    final rememberedId = _uncategorizedCategoryIds[monthKey];
+    if (rememberedId != null) {
+      final remembered = _categoryById(budget, rememberedId);
+      if (remembered != null) return remembered;
+      _uncategorizedCategoryIds.remove(monthKey);
+      _saveUncategorizedCategoryIds();
+    }
+
+    for (final category in budget.categories) {
+      if (_isUncategorizedName(category.name)) {
+        _rememberUncategorizedCategory(budget, category.id);
+        return category;
+      }
+    }
+
+    return null;
+  }
+
+  Category _ensureUncategorized(MonthBudget b) {
+    final existing = _findUncategorized(b);
+    if (existing != null) return existing;
+
     final cat = Category(
       id: _rid(),
-      name: 'Uncategorized',
-      emoji: '🗂️',
+      name: uncategorizedName,
+      emoji: uncategorizedEmoji,
     );
     b.categories.add(cat);
+    _rememberUncategorizedCategory(b, cat.id);
     return cat;
+  }
+
+  Category ensureUncategorizedForCurrentBudget() {
+    final budget = currentBudget!;
+    _assertEditable(budget);
+    return _ensureUncategorized(budget);
+  }
+
+  bool isUncategorizedCategory(Category category, {MonthBudget? budget}) {
+    final targetBudget = budget ?? currentBudget;
+    if (targetBudget == null) return _isUncategorizedName(category.name);
+    return _findUncategorized(targetBudget)?.id == category.id;
+  }
+
+  String resolveExpenseCategoryId(String? categoryId) {
+    final budget = currentBudget!;
+    if (categoryId != null &&
+        budget.categories.any((c) => c.id == categoryId)) {
+      return categoryId;
+    }
+    return _ensureUncategorized(budget).id;
   }
 
   void _assertEditable(MonthBudget b) {
@@ -146,6 +259,15 @@ class BudgetStore extends ChangeNotifier {
 
   Future<void> load() async {
     // Prepare file
+    _prefs = await SharedPreferences.getInstance();
+    _uncategorizedCategoryIds
+      ..clear()
+      ..addAll(
+        _decodeUncategorizedCategoryIds(
+          _prefs!.getString(_uncategorizedCategoryIdsPrefsKey),
+        ),
+      );
+
     final dir = await getApplicationDocumentsDirectory();
     _dbFile = File('${dir.path}/budgets.json');
 
@@ -173,7 +295,7 @@ class BudgetStore extends ChangeNotifier {
       }
     } else {
       // Fallback to previous prefs
-      final prefs = await SharedPreferences.getInstance();
+      final prefs = _prefs!;
       final code = prefs.getString('currency_code');
       final savedThemeMode = prefs.getString('theme_mode');
       final ym = prefs.getString('selected_ym');
@@ -207,6 +329,7 @@ class BudgetStore extends ChangeNotifier {
       await _dbFile!.delete();
     }
     await tmp.rename(_dbFile!.path);
+    await _saveUncategorizedCategoryIds();
   }
 
   void _scheduleSave() {
@@ -270,14 +393,17 @@ class BudgetStore extends ChangeNotifier {
     _saveDebounce?.cancel();
     _budgets.clear();
     _dismissedTipIds.clear();
+    _uncategorizedCategoryIds.clear();
     selectedYMKey = null;
     currency = Currencies.list.first;
     themeMode = ThemeMode.system;
 
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = _prefs ?? await SharedPreferences.getInstance();
+    _prefs = prefs;
     await prefs.remove('currency_code');
     await prefs.remove('theme_mode');
     await prefs.remove('selected_ym');
+    await prefs.remove(_uncategorizedCategoryIdsPrefsKey);
 
     if (_dbFile == null) {
       final dir = await getApplicationDocumentsDirectory();
@@ -315,6 +441,8 @@ class BudgetStore extends ChangeNotifier {
   bool deleteMonth(String ymKey) {
     final removed = _budgets.remove(ymKey);
     if (removed == null) return false;
+    _uncategorizedCategoryIds.remove(ymKey);
+    _saveUncategorizedCategoryIds();
     if (selectedYMKey == ymKey) {
       final activeKeys = activeMonthKeysDesc;
       selectedYMKey = activeKeys.isNotEmpty ? activeKeys.first : null;
@@ -404,10 +532,12 @@ class BudgetStore extends ChangeNotifier {
     final b = currentBudget!;
     _assertEditable(b);
     final cat = b.categories.firstWhere((c) => c.id == categoryId);
+    final isUncategorized = isUncategorizedCategory(cat, budget: b);
 
     final nextName = (name ?? cat.name).trim();
-    final nextEmoji = (emoji ?? cat.emoji).trim();
-    final nextAllocated = allocated ?? cat.allocated;
+    final nextEmoji =
+        isUncategorized ? uncategorizedEmoji : (emoji ?? cat.emoji).trim();
+    final nextAllocated = isUncategorized ? 0.0 : (allocated ?? cat.allocated);
 
     if (nextName.isEmpty) {
       throw Exception('Category name cannot be empty.');
@@ -424,7 +554,7 @@ class BudgetStore extends ChangeNotifier {
     _validateTotalAllocated(b, projectedTotalAllocated);
 
     cat.name = nextName;
-    cat.emoji = nextEmoji.isEmpty ? '🗂️' : nextEmoji;
+    cat.emoji = nextEmoji.isEmpty ? uncategorizedEmoji : nextEmoji;
     cat.allocated = nextAllocated;
 
     _scheduleSave();
@@ -442,6 +572,7 @@ class BudgetStore extends ChangeNotifier {
     if (categoryIndex < 0) return;
 
     final category = b.categories[categoryIndex];
+    final isUncategorized = isUncategorizedCategory(category, budget: b);
     if (category.expenses.isNotEmpty && !deleteExpenses) {
       if (moveExpensesToCategoryId == null ||
           moveExpensesToCategoryId == categoryId) {
@@ -458,6 +589,9 @@ class BudgetStore extends ChangeNotifier {
     }
 
     b.categories.removeAt(categoryIndex);
+    if (isUncategorized) {
+      _forgetUncategorizedCategory(b, expectedCategoryId: categoryId);
+    }
     _scheduleSave();
     notifyListeners();
   }
@@ -476,6 +610,7 @@ class BudgetStore extends ChangeNotifier {
     }
     for (final entry in amounts.entries) {
       final cat = b.categories.firstWhere((c) => c.id == entry.key);
+      if (isUncategorizedCategory(cat, budget: b)) continue;
       cat.allocated += entry.value;
     }
     _scheduleSave();
@@ -507,7 +642,9 @@ class BudgetStore extends ChangeNotifier {
     double newTotalAllocated = 0.0;
 
     for (final c in b.categories) {
-      final v = newAllocatedByCategoryId[c.id] ?? c.allocated;
+      final v = isUncategorizedCategory(c, budget: b)
+          ? 0.0
+          : (newAllocatedByCategoryId[c.id] ?? c.allocated);
       if (v.isNaN || v.isInfinite || v < 0) {
         throw Exception('Invalid allocation for "${c.name}".');
       }
@@ -518,7 +655,9 @@ class BudgetStore extends ChangeNotifier {
 
     for (final c in b.categories) {
       if (newAllocatedByCategoryId.containsKey(c.id)) {
-        c.allocated = newAllocatedByCategoryId[c.id]!;
+        c.allocated = isUncategorizedCategory(c, budget: b)
+            ? 0.0
+            : newAllocatedByCategoryId[c.id]!;
       }
     }
 

--- a/lib/widgets/category_card.dart
+++ b/lib/widgets/category_card.dart
@@ -4,12 +4,14 @@ import '../utils/format.dart';
 
 class CategoryCard extends StatelessWidget {
   final Category category;
+  final bool isUncategorized;
   final String currencySymbol;
   final VoidCallback? onTap;
   final VoidCallback? onLongPress;
   const CategoryCard({
     super.key,
     required this.category,
+    required this.isUncategorized,
     required this.currencySymbol,
     this.onTap,
     this.onLongPress,
@@ -20,8 +22,6 @@ class CategoryCard extends StatelessWidget {
     final double spent = category.spent;
     final double allocated = category.allocated;
     final double remaining = category.remaining;
-    final bool isUncategorized =
-        category.name.trim().toLowerCase() == 'uncategorized';
 
     // clamp() -> num, so call .toDouble()
     final double ratio =

--- a/lib/widgets/delete_category_dialog.dart
+++ b/lib/widgets/delete_category_dialog.dart
@@ -64,7 +64,7 @@ class _DeleteCategoryDialogState extends State<DeleteCategoryDialog> {
           children: [
             Text(
               _hasExpenses
-                  ? 'This category has $expenseCount expense${expenseCount == 1 ? '' : 's'} worth ${Format.money(expenseTotal, symbol: widget.currencySymbol)}.'
+                  ? 'This category has $expenseCount expense${expenseCount == 1 ? '' : 's'} worth ${Format.money(expenseTotal, symbol: widget.currencySymbol)}'
                   : 'This category has no expenses. Its limit and history on this screen will be removed.',
             ),
             if (_hasExpenses) ...[

--- a/lib/widgets/edit_category_dialog.dart
+++ b/lib/widgets/edit_category_dialog.dart
@@ -22,12 +22,16 @@ class EditCategoryDialog extends StatefulWidget {
   final String initialName;
   final String initialEmoji;
   final double initialAllocated;
+  final bool allowEmojiEditing;
+  final bool showLimitField;
 
   const EditCategoryDialog({
     super.key,
     required this.initialName,
     required this.initialEmoji,
     required this.initialAllocated,
+    this.allowEmojiEditing = true,
+    this.showLimitField = true,
   });
 
   @override
@@ -76,10 +80,19 @@ class _EditCategoryDialogState extends State<EditCategoryDialog> {
               controller: _nameCtrl,
               decoration: InputDecoration(
                 labelText: 'Category name',
-                prefixIcon: EmojiPrefixButton(
-                  emoji: _selectedEmoji,
-                  onTap: _pickEmoji,
-                ),
+                prefixIcon: widget.allowEmojiEditing
+                    ? EmojiPrefixButton(
+                        emoji: _selectedEmoji,
+                        onTap: _pickEmoji,
+                      )
+                    : Padding(
+                        padding: const EdgeInsets.only(top: 10),
+                        child: Text(
+                          _selectedEmoji,
+                          textAlign: TextAlign.center,
+                          style: const TextStyle(fontSize: 22, height: 1),
+                        ),
+                      ),
                 prefixIconConstraints: const BoxConstraints(
                   minWidth: 44,
                   minHeight: 44,
@@ -90,27 +103,29 @@ class _EditCategoryDialogState extends State<EditCategoryDialog> {
                   ? 'Please enter a name'
                   : null,
             ),
-            const SizedBox(height: 8),
-            TextFormField(
-              controller: _limitCtrl,
-              keyboardType: const TextInputType.numberWithOptions(
-                signed: false,
-                decimal: true,
+            if (widget.showLimitField) ...[
+              const SizedBox(height: 8),
+              TextFormField(
+                controller: _limitCtrl,
+                keyboardType: const TextInputType.numberWithOptions(
+                  signed: false,
+                  decimal: true,
+                ),
+                decoration: moneyAmountInputDecoration(
+                  context,
+                  currencySymbol: currencySymbol,
+                  labelText: 'Category limit',
+                ),
+                validator: (value) {
+                  final amount =
+                      double.tryParse(value?.trim().replaceAll(',', '.') ?? '');
+                  if (amount == null || amount < 0) {
+                    return 'Enter zero or a valid amount';
+                  }
+                  return null;
+                },
               ),
-              decoration: moneyAmountInputDecoration(
-                context,
-                currencySymbol: currencySymbol,
-                labelText: 'Category limit',
-              ),
-              validator: (value) {
-                final amount =
-                    double.tryParse(value?.trim().replaceAll(',', '.') ?? '');
-                if (amount == null || amount < 0) {
-                  return 'Enter zero or a valid amount';
-                }
-                return null;
-              },
-            ),
+            ],
           ],
         ),
       ),
@@ -127,8 +142,9 @@ class _EditCategoryDialogState extends State<EditCategoryDialog> {
               EditCategoryResult(
                 name: _nameCtrl.text.trim(),
                 emoji: _selectedEmoji,
-                allocated:
-                    double.parse(_limitCtrl.text.trim().replaceAll(',', '.')),
+                allocated: widget.showLimitField
+                    ? double.parse(_limitCtrl.text.trim().replaceAll(',', '.'))
+                    : widget.initialAllocated,
               ),
             );
           },

--- a/lib/widgets/emoji_selector.dart
+++ b/lib/widgets/emoji_selector.dart
@@ -23,7 +23,8 @@ class _EmojiSheetState extends State<_EmojiSheet> {
     // Common
     '😀', '😄', '😁', '🥹', '😊', '😉', '😍', '😘', '😎', '🤩', '🥳', '🤔',
     '😴', '🤯', '😭', '😡', '👍', '👎', '👏', '🙏', '💪',
-    '❤️', '🧡', '💛', '💚', '💙', '💜', '🖤', '🤍', '🤎', '💡', '🔥', '✨', '⭐',
+    '❤️', '🧡', '💛', '💚', '💙', '💜', '🖤', '🤍', '🤎', '💌', '💡', '🔥', '✨',
+    '⭐',
     '🌟', '⚡', '☀️', '🌧️', '❄️', '🌈',
     // Food
     '🍔', '🍟', '🌮', '🍕', '🍝', '🍣', '🍱', '🍜', '🥗', '🍎', '🍌', '🍓',
@@ -35,7 +36,7 @@ class _EmojiSheetState extends State<_EmojiSheet> {
     // Activities
     '⚽', '🏀', '🎾', '🎮', '🎲', '🎵', '🎧', '🎸', '🎬', '📚',
     // Objects
-    '🧹', '🛠️', '🧰', '🧼', '🧴', '🪥', '📦', '🎁', '🗂️',
+    '🧹', '🛠️', '🧰', '🧼', '🧴', '🪥', '🦷', '📱', '📅', '📦', '🎁', '🗂️',
   ];
 
   static final Map<String, List<String>> emojiTags = {
@@ -72,6 +73,7 @@ class _EmojiSheetState extends State<_EmojiSheet> {
     '🖤': ['heart', 'love', 'black'],
     '🤍': ['heart', 'love', 'white'],
     '🤎': ['heart', 'love', 'brown'],
+    '💌': ['love letter', 'letter', 'mail', 'romance', 'envelope', 'heart'],
     '💡': ['idea', 'light', 'bulb'],
     '🔥': ['fire', 'hot', 'flame'],
     '✨': ['sparkles', 'shine', 'magic'],
@@ -146,6 +148,9 @@ class _EmojiSheetState extends State<_EmojiSheet> {
     '🧼': ['soap', 'clean'],
     '🧴': ['bottle', 'clean', 'care'],
     '🪥': ['toothbrush', 'teeth'],
+    '🦷': ['tooth', 'teeth', 'dentist', 'dental'],
+    '📱': ['phone', 'mobile', 'call', 'telephone'],
+    '📅': ['calendar', 'date', 'schedule', 'appointment'],
     '📦': ['package', 'parcel', 'box'],
     '🎁': ['gift', 'present'],
     '🗂️': ['organize', 'folder', 'files'],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: truly_budget
 description: A clean Flutter budget app — TrulyBudget
 publish_to: 'none'
-version: 1.2.2+5
+version: 1.2.3+6
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/tests/budget_store_test.dart
+++ b/tests/budget_store_test.dart
@@ -106,5 +106,39 @@ void main() {
         ),
       );
     });
+
+    test('keeps uncategorized behavior after renaming the category', () {
+      final uncategorized = store.ensureUncategorizedForCurrentBudget();
+      store.addExpense(uncategorized.id, 'Coffee', 4.5);
+
+      store.updateCategory(
+        uncategorized.id,
+        name: 'Floating expenses',
+        emoji: '☕',
+        allocated: 25,
+      );
+
+      final updated = store.currentBudget!.categories.single;
+      expect(updated.name, 'Floating expenses');
+      expect(updated.emoji, BudgetStore.uncategorizedEmoji);
+      expect(updated.allocated, 0);
+      expect(store.isUncategorizedCategory(updated), isTrue);
+      expect(store.debtForBudget(store.currentBudget!), 4.5);
+    });
+
+    test('routes no-category expenses to the renamed uncategorized category',
+        () {
+      final uncategorized = store.ensureUncategorizedForCurrentBudget();
+      store.updateCategory(uncategorized.id, name: 'Floating expenses');
+
+      final categoryId = store.resolveExpenseCategoryId(null);
+      store.addExpense(categoryId, 'Parking', 8);
+
+      final updated = store.currentBudget!.categories.single;
+      expect(categoryId, uncategorized.id);
+      expect(updated.name, 'Floating expenses');
+      expect(store.isUncategorizedCategory(updated), isTrue);
+      expect(updated.expenses.single.note, 'Parking');
+    });
   });
 }

--- a/tests/edit_category_dialog_test.dart
+++ b/tests/edit_category_dialog_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:truly_budget/state/budget_store.dart';
+import 'package:truly_budget/widgets/edit_category_dialog.dart';
+
+void main() {
+  Widget buildTestApp(BudgetStore store, Widget child) {
+    return ChangeNotifierProvider<BudgetStore>.value(
+      value: store,
+      child: MaterialApp(home: child),
+    );
+  }
+
+  testWidgets(
+    'uncategorized categories cannot edit emoji or limit',
+    (tester) async {
+      final store = BudgetStore();
+
+      await tester.pumpWidget(
+        buildTestApp(
+          store,
+          const EditCategoryDialog(
+            initialName: 'Floating expenses',
+            initialEmoji: '🗂️',
+            initialAllocated: 0,
+            allowEmojiEditing: false,
+            showLimitField: false,
+          ),
+        ),
+      );
+
+      expect(find.byTooltip('Choose emoji'), findsNothing);
+      expect(find.byType(TextFormField), findsOneWidget);
+      expect(find.text('Floating expenses'), findsOneWidget);
+    },
+  );
+}

--- a/tests/emoji_selector_test.dart
+++ b/tests/emoji_selector_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:truly_budget/widgets/emoji_selector.dart';
+
+void main() {
+  testWidgets('emoji selector includes new searchable emojis', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: ElevatedButton(
+              onPressed: () =>
+                  pickEmoji(tester.element(find.byType(ElevatedButton))),
+              child: const Text('Open emoji picker'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open emoji picker'));
+    await tester.pumpAndSettle();
+
+    final searchField = find.byType(TextField);
+
+    await tester.enterText(searchField, 'tooth');
+    await tester.pumpAndSettle();
+    expect(find.text('🦷'), findsOneWidget);
+
+    await tester.enterText(searchField, 'phone');
+    await tester.pumpAndSettle();
+    expect(find.text('📱'), findsOneWidget);
+
+    await tester.enterText(searchField, 'calendar');
+    await tester.pumpAndSettle();
+    expect(find.text('📅'), findsOneWidget);
+
+    await tester.enterText(searchField, 'love letter');
+    await tester.pumpAndSettle();
+    expect(find.text('💌'), findsOneWidget);
+  });
+}

--- a/tests/month_screen_test.dart
+++ b/tests/month_screen_test.dart
@@ -128,5 +128,61 @@ void main() {
         await tester.pump(const Duration(milliseconds: 300));
       },
     );
+
+    testWidgets(
+      'renamed uncategorized category is not treated as over-budget',
+      (tester) async {
+        final store = BudgetStore();
+        store.createMonth(2026, 3, select: true);
+
+        final uncategorized = store.ensureUncategorizedForCurrentBudget();
+        store.addExpense(uncategorized.id, 'Coffee', 4.5);
+        store.updateCategory(uncategorized.id, name: 'Floating expenses');
+        await tester.pump(const Duration(milliseconds: 300));
+
+        await tester.pumpWidget(buildTestApp(store, const MonthScreen()));
+
+        expect(find.text('Over-budget categories'), findsNothing);
+        expect(find.text('Floating expenses'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'selecting no category still adds expenses to the renamed uncategorized category',
+      (tester) async {
+        final store = BudgetStore();
+        store.createMonth(2026, 3, select: true);
+
+        final uncategorized = store.ensureUncategorizedForCurrentBudget();
+        store.updateCategory(uncategorized.id, name: 'Floating expenses');
+        await tester.pump(const Duration(milliseconds: 300));
+
+        await tester.pumpWidget(buildTestApp(store, const MonthScreen()));
+
+        await tester.tap(find.byTooltip('Open quick actions'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Add expense'));
+        await tester.pumpAndSettle();
+
+        await tester.enterText(find.byType(TextFormField).first, 'Parking');
+        await tester.enterText(find.byType(TextFormField).at(1), '8');
+        await tester.tap(find.widgetWithText(FilledButton, 'Add'));
+        await tester.pumpAndSettle();
+
+        expect(store.currentBudget!.categories, hasLength(1));
+        expect(store.currentBudget!.categories.single.id, uncategorized.id);
+        expect(
+            store.currentBudget!.categories.single.name, 'Floating expenses');
+        expect(
+          store.isUncategorizedCategory(store.currentBudget!.categories.single),
+          isTrue,
+        );
+        expect(store.currentBudget!.categories.single.expenses, hasLength(1));
+        expect(
+          store.currentBudget!.categories.single.expenses.single.note,
+          'Parking',
+        );
+      },
+    );
   });
 }

--- a/tests/persistence_schema_test.dart
+++ b/tests/persistence_schema_test.dart
@@ -63,7 +63,7 @@ void main() {
         date: aprilExpenseDate,
         emoji: '🚆',
       );
-
+      // This must NOT change
       expect(
         store.exportData(),
         equals({


### PR DESCRIPTION
- Preserve the special uncategorized category behaviour without changing the `budgets.json` schema
- prevent emoji and limit edits for the uncategorized category while still allowing renaming
- make the `No category` quick-add flow continue routing expenses into the same uncategorized bucket after rename
