### PR TITLE
#63: If a category is over-budget, the category tile should show it 

### DIFF
--- a/lib/screens/month_screen.dart
+++ b/lib/screens/month_screen.dart
@@ -942,7 +942,7 @@ class _OverBudgetCategoriesCard extends StatelessWidget {
                   children: [
                     Expanded(
                       child: Text(
-                        'Over-budget categories',
+                        'Over-budget',
                         style: theme.textTheme.titleMedium,
                       ),
                     ),

--- a/lib/widgets/category_card.dart
+++ b/lib/widgets/category_card.dart
@@ -22,6 +22,7 @@ class CategoryCard extends StatelessWidget {
     final double spent = category.spent;
     final double allocated = category.allocated;
     final double remaining = category.remaining;
+    final bool isOverBudget = !isUncategorized && remaining < -1e-6;
 
     // clamp() -> num, so call .toDouble()
     final double ratio =
@@ -29,9 +30,15 @@ class CategoryCard extends StatelessWidget {
 
     final Color barColor = isUncategorized
         ? Colors.blueGrey
-        : (ratio <= 0.5
-            ? Colors.green
-            : (ratio <= 0.8 ? Colors.orange : Colors.red));
+        : (isOverBudget
+            ? Colors.red
+            : ratio <= 0.5
+                ? Colors.green
+                : (ratio <= 0.8 ? Colors.orange : Colors.red));
+    final displayedRemaining =
+        isOverBudget ? remaining : remaining.clamp(0, double.infinity);
+    final String balanceText =
+        'Left: ${Format.money(displayedRemaining, symbol: currencySymbol)}';
 
     return Card(
       child: InkWell(
@@ -77,8 +84,11 @@ class CategoryCard extends StatelessWidget {
                   Text('Spent: ${Format.money(spent, symbol: currencySymbol)}'),
                   if (!isUncategorized)
                     Text(
-                      'Left: ${Format.money(remaining.clamp(0, double.infinity), symbol: currencySymbol)}',
-                      style: const TextStyle(fontWeight: FontWeight.w700),
+                      balanceText,
+                      style: TextStyle(
+                        color: isOverBudget ? Colors.red.shade700 : null,
+                        fontWeight: FontWeight.w700,
+                      ),
                     ),
                 ],
               )

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: truly_budget
 description: A clean Flutter budget app — TrulyBudget
 publish_to: 'none'
-version: 1.3.1+8
+version: 1.3.2+9
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/tests/category_card_test.dart
+++ b/tests/category_card_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:truly_budget/models/category.dart';
+import 'package:truly_budget/models/expense.dart';
+import 'package:truly_budget/utils/format.dart';
+import 'package:truly_budget/widgets/category_card.dart';
+
+void main() {
+  testWidgets('over-budget category shows the negative amount left in red',
+      (tester) async {
+    const currencySymbol = r'$';
+    final category = Category(
+      id: 'groceries',
+      name: 'Groceries',
+      emoji: 'G',
+      allocated: 50,
+      expenses: [
+        Expense(note: 'Shop', amount: 70),
+      ],
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: CategoryCard(
+            category: category,
+            isUncategorized: false,
+            currencySymbol: currencySymbol,
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      find.text('Left: ${Format.money(0, symbol: currencySymbol)}'),
+      findsNothing,
+    );
+
+    expect(
+      find.text('Overspent: ${Format.money(20, symbol: currencySymbol)}'),
+      findsNothing,
+    );
+
+    final negativeLeftText =
+        find.text('Left: ${Format.money(-20, symbol: currencySymbol)}');
+    expect(negativeLeftText, findsOneWidget);
+
+    final textWidget = tester.widget<Text>(negativeLeftText);
+    expect(textWidget.style?.color, Colors.red.shade700);
+  });
+}


### PR DESCRIPTION
- If a category is over-budget, the category tile should show the overspent amount instead of "Left: 0"
